### PR TITLE
Update GitHub Wiki links to new documentation site

### DIFF
--- a/index-vi-vn.html
+++ b/index-vi-vn.html
@@ -161,7 +161,7 @@
               </span>
             </label>
             <div class="hidden sm:flex">
-              <a href="https://github.com/seriaati/hoyo-buddy/wiki/Getting-Started" target="_blank" rel="noopener"
+              <a href="https://hb-docs.seria.moe/vi/docs/Getting-Started" target="_blank" rel="noopener"
                 class="loginBtn px-[22px] py-2 text-base font-medium text-white hover:opacity-70">
                 Bắt đầu
               </a>
@@ -188,7 +188,7 @@
             </p>
             <ul class="mb-10 flex flex-wrap items-center justify-center gap-5">
               <li>
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki/Getting-Started" target="_blank" rel="noopener"
+                <a href="https://hb-docs.seria.moe/vi/docs/Getting-Started" target="_blank" rel="noopener"
                   class="inline-flex items-center justify-center rounded-md bg-white px-7 py-[14px] text-center text-base font-medium text-dark shadow-1 transition duration-300 ease-in-out hover:bg-gray-2 hover:text-body-color">
                   Bắt đầu
                 </a>
@@ -669,7 +669,7 @@
               <p class="mx-auto mb-6 max-w-[515px] text-base leading-[1.5] text-white">
                 Có rất nhiều bot Discord liên quan đến Hoyoverse trên thị trường, vậy tại sao lại chọn Hoyo Buddy? Điều gì khiến Hoyo Buddy nổi bật so với những sản phẩm khác, kể cả những sản phẩm bạn có thể đang sử dụng?
               </p>
-              <a href="https://github.com/seriaati/hoyo-buddy/wiki/Why-Hoyo-Buddy%3F" target="_blank" rel="noopener"
+              <a href="https://hb-docs.seria.moe/vi/docs/Why-Hoyo-Buddy" target="_blank" rel="noopener"
                 class="inline-block rounded-md border border-transparent bg-secondary px-7 py-3 text-base font-medium text-white transition hover:bg-[#0BB489]">
                 Đọc thêm tại đây
               </a>
@@ -939,10 +939,10 @@
               </h3>
               <p class="text-base text-body-color dark:text-dark-6">
                 Vui lòng đọc trang
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki/Account-Security" rel="noopener" target="_blank"
+                <a href="https://hb-docs.seria.moe/vi/docs/Account-Security" rel="noopener" target="_blank"
                   class="text-primary hover:underline">
                   Bảo Mật Tài Khoản
-                </a> trên wiki GitHub để biết thêm thông tin. Để bảo mật dữ liệu, vui lòng đọc
+                </a> trên Wiki để biết thêm thông tin. Để bảo mật dữ liệu, vui lòng đọc
                 <a href="https://github.com/seriaati/hoyo-buddy/blob/main/PRIVACY.md" rel="noopener" target="_blank"
                   class="text-primary hover:underline">
                   Chính Sách Quyền Riêng Tư
@@ -1197,7 +1197,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki"
+                <a href="https://hb-docs.seria.moe/vi"
                   class="mb-3 inline-block text-base text-gray-7 hover:text-primary">
                   Wiki
                 </a>

--- a/index-zh-tw.html
+++ b/index-zh-tw.html
@@ -160,7 +160,7 @@
               </span>
             </label>
             <div class="hidden sm:flex">
-              <a href="https://github.com/seriaati/hoyo-buddy/wiki/%E9%96%8B%E5%A7%8B%E4%BD%BF%E7%94%A8" target="_blank" rel="noopener"
+              <a href="https://hb-docs.seria.moe/zh-Hant/docs/Getting-Started" target="_blank" rel="noopener"
                 class="loginBtn px-[22px] py-2 text-base font-medium text-white hover:opacity-70">
                 開始使用
               </a>
@@ -187,7 +187,7 @@
             </p>
             <ul class="mb-10 flex flex-wrap items-center justify-center gap-5">
               <li>
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki/%E9%96%8B%E5%A7%8B%E4%BD%BF%E7%94%A8"
+                <a href="https://hb-docs.seria.moe/zh-Hant/docs/Getting-Started"
                   target="_blank" rel="noopener"
                   class="inline-flex items-center justify-center rounded-md bg-white px-7 py-[14px] text-center text-base font-medium text-dark shadow-1 transition duration-300 ease-in-out hover:bg-gray-2 hover:text-body-color">
                   開始使用
@@ -668,7 +668,7 @@
               <p class="mx-auto mb-6 max-w-[515px] text-base leading-[1.5] text-white">
                 市面上有許多與 Hoyoverse 相關的 Discord 機器人，那麼為什麼要選擇 Hoyo Buddy? Hoyo Buddy 有什麼與眾不同之處，使其勝過其他你可能已在使用的機器人？
               </p>
-              <a rel="noopener" href="https://github.com/seriaati/hoyo-buddy/wiki/Hoyo-Buddy-%E6%9C%89%E5%93%AA%E4%BA%9B%E7%89%B9%E9%BB%9E%EF%BC%9F"
+              <a rel="noopener" href="https://hb-docs.seria.moe/zh-Hant/docs/Why-Hoyo-Buddy"
                 target="_blank"
                 class="inline-block rounded-md border border-transparent bg-secondary px-7 py-3 text-base font-medium text-white transition hover:bg-[#0BB489]">
                 查看介紹
@@ -938,8 +938,8 @@
                 Hoyo Buddy 在使用上會有安全疑慮嗎?
               </h3>
               <p class="text-base text-body-color dark:text-dark-6">
-                請詳閱 GitHub 維基上的
-                <a rel="noopener" href="https://github.com/seriaati/hoyo-buddy/wiki/Account-Security" target="_blank"
+                請詳閱維基上的
+                <a rel="noopener" href="https://hb-docs.seria.moe/zh-Hant/docs/Account-Security" target="_blank"
                   class="text-primary hover:underline">
                   帳戶安全
                 </a> 頁面來獲取更多資訊。資料隱私方面, 請參閱
@@ -1197,7 +1197,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki"
+                <a href="https://hb-docs.seria.moe/zh-Hant"
                   class="mb-3 inline-block text-base text-gray-7 hover:text-primary">
                   維基
                 </a>

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
               </span>
             </label>
             <div class="hidden sm:flex">
-              <a href="https://github.com/seriaati/hoyo-buddy/wiki/Getting-Started" target="_blank" rel="noopener"
+              <a href="https://hb-docs.seria.moe/docs/Getting-Started" target="_blank" rel="noopener"
                 class="loginBtn px-[22px] py-2 text-base font-medium text-white hover:opacity-70">
                 Get Started
               </a>
@@ -189,7 +189,7 @@
             </p>
             <ul class="mb-10 flex flex-wrap items-center justify-center gap-5">
               <li>
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki/Getting-Started" target="_blank" rel="noopener"
+                <a href="https://hb-docs.seria.moe/docs/Getting-Started" target="_blank" rel="noopener"
                   class="inline-flex items-center justify-center rounded-md bg-white px-7 py-[14px] text-center text-base font-medium text-dark shadow-1 transition duration-300 ease-in-out hover:bg-gray-2 hover:text-body-color">
                   Get Started
                 </a>
@@ -677,7 +677,7 @@
                 There are numerous Hoyoverse-related Discord bots on the market, so why choose Hoyo Buddy? What makes
                 Hoyo Buddy stand out from the others, including the ones you might already be using?
               </p>
-              <a href="https://github.com/seriaati/hoyo-buddy/wiki/Why-Hoyo-Buddy%3F" target="_blank" rel="noopener"
+              <a href="https://hb-docs.seria.moe/docs/Why-Hoyo-Buddy" target="_blank" rel="noopener"
                 class="inline-block rounded-md border border-transparent bg-secondary px-7 py-3 text-base font-medium text-white transition hover:bg-[#0BB489]">
                 Read about it
               </a>
@@ -953,10 +953,10 @@
               </h3>
               <p class="text-base text-body-color dark:text-dark-6">
                 Please read the
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki/Account-Security" rel="noopener" target="_blank"
+                <a href="https://hb-docs.seria.moe/docs/Account-Security" rel="noopener" target="_blank"
                   class="text-primary hover:underline">
                   Account Security
-                </a> page on the GitHub wiki for more information. For data privacy, please read the
+                </a> page on the Wiki for more information. For data privacy, please read the
                 <a href="https://github.com/seriaati/hoyo-buddy/blob/main/PRIVACY.md" rel="noopener" target="_blank"
                   class="text-primary hover:underline">
                   Privacy Policy
@@ -1211,7 +1211,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/seriaati/hoyo-buddy/wiki"
+                <a href="https://hb-docs.seria.moe/"
                   class="mb-3 inline-block text-base text-gray-7 hover:text-primary">
                   Wiki
                 </a>


### PR DESCRIPTION
Replace outdated GitHub Wiki links with updated links to the new documentation site for improved accessibility and user experience.